### PR TITLE
Prevent Fan2 menu with EXTRUDERS =1

### DIFF
--- a/Marlin/pins_RIGIDBOARD.h
+++ b/Marlin/pins_RIGIDBOARD.h
@@ -87,6 +87,13 @@
 
 #undef  FAN_PIN
 #define FAN_PIN             8 // Same as RAMPS_13_EEF
+#if EXTRUDERS == 2
+  #undef FAN1_PIN
+  #define FAN1_PIN         11
+#else
+  #undef FAN1_PIN
+  #define FAN1_PIN         -1
+#endif
 
 //
 // Misc. Functions


### PR DESCRIPTION
Fan2 speed menu edit item shows up on the Tune menu because of Logic in the RAMPS.h file when MOSFET_D_PIN is defined previous to including it in pins_Rigidbot.h 
This change adds a redefine for the fan1_pin value preventing that menu item unless EXTRUDERS == 2 at which point that menu item is desired.